### PR TITLE
[TDD-Feature] : 뉴스 가져오는 api 구현 완료. #1

### DIFF
--- a/HeyBunny.xcodeproj/project.pbxproj
+++ b/HeyBunny.xcodeproj/project.pbxproj
@@ -7,6 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11FA6B5F5A50553C6E6E7D62 /* Pods_HeyBunny_HeyBunnyUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 949D3428D7119DFBB415A634 /* Pods_HeyBunny_HeyBunnyUITests.framework */; };
+		4D717A92E381A617CA55D615 /* Pods_HeyBunny.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AB833556110842C6BB142DE /* Pods_HeyBunny.framework */; };
+		50AEF392488BB81C182D96ED /* Pods_HeyBunnyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E49B47782F0918F20351210 /* Pods_HeyBunnyTests.framework */; };
+		7257516128CB23FA007322FD /* NewsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257516028CB23FA007322FD /* NewsRepositoryTests.swift */; };
+		7257516428CB2751007322FD /* NewServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257516328CB2751007322FD /* NewServiceStub.swift */; };
+		7257516628CB276E007322FD /* NewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257516528CB276E007322FD /* NewsService.swift */; };
+		7257516928CB2D9E007322FD /* NewsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257516828CB2D9E007322FD /* NewsRepository.swift */; };
+		7257516B28CB2ED1007322FD /* NewsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257516A28CB2ED1007322FD /* NewsAPI.swift */; };
+		7257517128CB43CF007322FD /* News.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7257517028CB43CE007322FD /* News.swift */; };
 		72C6232428CB1DD90023A368 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C6232328CB1DD90023A368 /* AppDelegate.swift */; };
 		72C6232628CB1DD90023A368 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C6232528CB1DD90023A368 /* SceneDelegate.swift */; };
 		72C6232828CB1DD90023A368 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C6232728CB1DD90023A368 /* ViewController.swift */; };
@@ -36,6 +45,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0E49B47782F0918F20351210 /* Pods_HeyBunnyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HeyBunnyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1AB833556110842C6BB142DE /* Pods_HeyBunny.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HeyBunny.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		226FDC72EC9024950B56EB37 /* Pods-HeyBunnyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeyBunnyTests.release.xcconfig"; path = "Target Support Files/Pods-HeyBunnyTests/Pods-HeyBunnyTests.release.xcconfig"; sourceTree = "<group>"; };
+		40508C30C5C934B28D5ED6E0 /* Pods-HeyBunny-HeyBunnyUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeyBunny-HeyBunnyUITests.debug.xcconfig"; path = "Target Support Files/Pods-HeyBunny-HeyBunnyUITests/Pods-HeyBunny-HeyBunnyUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		498630D3313B0A7CC557F52E /* Pods-HeyBunnyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeyBunnyTests.debug.xcconfig"; path = "Target Support Files/Pods-HeyBunnyTests/Pods-HeyBunnyTests.debug.xcconfig"; sourceTree = "<group>"; };
+		7257516028CB23FA007322FD /* NewsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsRepositoryTests.swift; sourceTree = "<group>"; };
+		7257516328CB2751007322FD /* NewServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewServiceStub.swift; sourceTree = "<group>"; };
+		7257516528CB276E007322FD /* NewsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsService.swift; sourceTree = "<group>"; };
+		7257516828CB2D9E007322FD /* NewsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsRepository.swift; sourceTree = "<group>"; };
+		7257516A28CB2ED1007322FD /* NewsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsAPI.swift; sourceTree = "<group>"; };
+		7257517028CB43CE007322FD /* News.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = News.swift; sourceTree = "<group>"; };
 		72C6232028CB1DD90023A368 /* HeyBunny.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HeyBunny.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		72C6232328CB1DD90023A368 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		72C6232528CB1DD90023A368 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -49,6 +69,10 @@
 		72C6234028CB1DDD0023A368 /* HeyBunnyUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HeyBunnyUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		72C6234428CB1DDD0023A368 /* HeyBunnyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeyBunnyUITests.swift; sourceTree = "<group>"; };
 		72C6234628CB1DDD0023A368 /* HeyBunnyUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeyBunnyUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		89ABCD971BF3D0E6C66C04D4 /* Pods-HeyBunny.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeyBunny.debug.xcconfig"; path = "Target Support Files/Pods-HeyBunny/Pods-HeyBunny.debug.xcconfig"; sourceTree = "<group>"; };
+		9181DE796AB614040B75F6D2 /* Pods-HeyBunny-HeyBunnyUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeyBunny-HeyBunnyUITests.release.xcconfig"; path = "Target Support Files/Pods-HeyBunny-HeyBunnyUITests/Pods-HeyBunny-HeyBunnyUITests.release.xcconfig"; sourceTree = "<group>"; };
+		949D3428D7119DFBB415A634 /* Pods_HeyBunny_HeyBunnyUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HeyBunny_HeyBunnyUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB1CB59C70B937355DACD786 /* Pods-HeyBunny.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HeyBunny.release.xcconfig"; path = "Target Support Files/Pods-HeyBunny/Pods-HeyBunny.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D717A92E381A617CA55D615 /* Pods_HeyBunny.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,6 +88,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50AEF392488BB81C182D96ED /* Pods_HeyBunnyTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,12 +96,62 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11FA6B5F5A50553C6E6E7D62 /* Pods_HeyBunny_HeyBunnyUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		20395401D1EC8A65AEAF6AA0 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1AB833556110842C6BB142DE /* Pods_HeyBunny.framework */,
+				949D3428D7119DFBB415A634 /* Pods_HeyBunny_HeyBunnyUITests.framework */,
+				0E49B47782F0918F20351210 /* Pods_HeyBunnyTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6FD3C7B5B0991169865464C9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				89ABCD971BF3D0E6C66C04D4 /* Pods-HeyBunny.debug.xcconfig */,
+				AB1CB59C70B937355DACD786 /* Pods-HeyBunny.release.xcconfig */,
+				40508C30C5C934B28D5ED6E0 /* Pods-HeyBunny-HeyBunnyUITests.debug.xcconfig */,
+				9181DE796AB614040B75F6D2 /* Pods-HeyBunny-HeyBunnyUITests.release.xcconfig */,
+				498630D3313B0A7CC557F52E /* Pods-HeyBunnyTests.debug.xcconfig */,
+				226FDC72EC9024950B56EB37 /* Pods-HeyBunnyTests.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		7257516228CB273A007322FD /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				7257516328CB2751007322FD /* NewServiceStub.swift */,
+			);
+			path = Mock;
+			sourceTree = "<group>";
+		};
+		7257516728CB2D8E007322FD /* network */ = {
+			isa = PBXGroup;
+			children = (
+				7257516528CB276E007322FD /* NewsService.swift */,
+				7257516828CB2D9E007322FD /* NewsRepository.swift */,
+				7257516A28CB2ED1007322FD /* NewsAPI.swift */,
+			);
+			path = network;
+			sourceTree = "<group>";
+		};
+		7257516F28CB43B3007322FD /* entity */ = {
+			isa = PBXGroup;
+			children = (
+				7257517028CB43CE007322FD /* News.swift */,
+			);
+			path = entity;
+			sourceTree = "<group>";
+		};
 		72C6231728CB1DD90023A368 = {
 			isa = PBXGroup;
 			children = (
@@ -83,6 +159,8 @@
 				72C6233928CB1DDD0023A368 /* HeyBunnyTests */,
 				72C6234328CB1DDD0023A368 /* HeyBunnyUITests */,
 				72C6232128CB1DD90023A368 /* Products */,
+				6FD3C7B5B0991169865464C9 /* Pods */,
+				20395401D1EC8A65AEAF6AA0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -99,6 +177,8 @@
 		72C6232228CB1DD90023A368 /* HeyBunny */ = {
 			isa = PBXGroup;
 			children = (
+				7257516F28CB43B3007322FD /* entity */,
+				7257516728CB2D8E007322FD /* network */,
 				72C6232328CB1DD90023A368 /* AppDelegate.swift */,
 				72C6232528CB1DD90023A368 /* SceneDelegate.swift */,
 				72C6232728CB1DD90023A368 /* ViewController.swift */,
@@ -113,7 +193,9 @@
 		72C6233928CB1DDD0023A368 /* HeyBunnyTests */ = {
 			isa = PBXGroup;
 			children = (
+				7257516228CB273A007322FD /* Mock */,
 				72C6233A28CB1DDD0023A368 /* HeyBunnyTests.swift */,
+				7257516028CB23FA007322FD /* NewsRepositoryTests.swift */,
 			);
 			path = HeyBunnyTests;
 			sourceTree = "<group>";
@@ -134,9 +216,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 72C6234A28CB1DDD0023A368 /* Build configuration list for PBXNativeTarget "HeyBunny" */;
 			buildPhases = (
+				99E85CA0378D54848E521BEC /* [CP] Check Pods Manifest.lock */,
 				72C6231C28CB1DD90023A368 /* Sources */,
 				72C6231D28CB1DD90023A368 /* Frameworks */,
 				72C6231E28CB1DD90023A368 /* Resources */,
+				1FE8BA00384000B1736CD259 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -151,9 +235,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 72C6234D28CB1DDD0023A368 /* Build configuration list for PBXNativeTarget "HeyBunnyTests" */;
 			buildPhases = (
+				92ED6C5966E54C940C38B18B /* [CP] Check Pods Manifest.lock */,
 				72C6233228CB1DDD0023A368 /* Sources */,
 				72C6233328CB1DDD0023A368 /* Frameworks */,
 				72C6233428CB1DDD0023A368 /* Resources */,
+				DC2F277257FCDD423B712533 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -169,9 +255,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 72C6235028CB1DDD0023A368 /* Build configuration list for PBXNativeTarget "HeyBunnyUITests" */;
 			buildPhases = (
+				F232CB2A47E5D6C14470A7AF /* [CP] Check Pods Manifest.lock */,
 				72C6233C28CB1DDD0023A368 /* Sources */,
 				72C6233D28CB1DDD0023A368 /* Frameworks */,
 				72C6233E28CB1DDD0023A368 /* Resources */,
+				11C78594FA24853FE8748CEB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -253,6 +341,126 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		11C78594FA24853FE8748CEB /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeyBunny-HeyBunnyUITests/Pods-HeyBunny-HeyBunnyUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeyBunny-HeyBunnyUITests/Pods-HeyBunny-HeyBunnyUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HeyBunny-HeyBunnyUITests/Pods-HeyBunny-HeyBunnyUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1FE8BA00384000B1736CD259 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeyBunny/Pods-HeyBunny-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeyBunny/Pods-HeyBunny-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HeyBunny/Pods-HeyBunny-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		92ED6C5966E54C940C38B18B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HeyBunnyTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		99E85CA0378D54848E521BEC /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HeyBunny-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DC2F277257FCDD423B712533 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeyBunnyTests/Pods-HeyBunnyTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HeyBunnyTests/Pods-HeyBunnyTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HeyBunnyTests/Pods-HeyBunnyTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F232CB2A47E5D6C14470A7AF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HeyBunny-HeyBunnyUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		72C6231C28CB1DD90023A368 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -260,7 +468,11 @@
 			files = (
 				72C6232828CB1DD90023A368 /* ViewController.swift in Sources */,
 				72C6232428CB1DD90023A368 /* AppDelegate.swift in Sources */,
+				7257516628CB276E007322FD /* NewsService.swift in Sources */,
 				72C6232628CB1DD90023A368 /* SceneDelegate.swift in Sources */,
+				7257517128CB43CF007322FD /* News.swift in Sources */,
+				7257516928CB2D9E007322FD /* NewsRepository.swift in Sources */,
+				7257516B28CB2ED1007322FD /* NewsAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -268,7 +480,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7257516128CB23FA007322FD /* NewsRepositoryTests.swift in Sources */,
 				72C6233B28CB1DDD0023A368 /* HeyBunnyTests.swift in Sources */,
+				7257516428CB2751007322FD /* NewServiceStub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -432,6 +646,7 @@
 		};
 		72C6234B28CB1DDD0023A368 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 89ABCD971BF3D0E6C66C04D4 /* Pods-HeyBunny.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -460,6 +675,7 @@
 		};
 		72C6234C28CB1DDD0023A368 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB1CB59C70B937355DACD786 /* Pods-HeyBunny.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -488,6 +704,7 @@
 		};
 		72C6234E28CB1DDD0023A368 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 498630D3313B0A7CC557F52E /* Pods-HeyBunnyTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -508,6 +725,7 @@
 		};
 		72C6234F28CB1DDD0023A368 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 226FDC72EC9024950B56EB37 /* Pods-HeyBunnyTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -528,6 +746,7 @@
 		};
 		72C6235128CB1DDD0023A368 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 40508C30C5C934B28D5ED6E0 /* Pods-HeyBunny-HeyBunnyUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -546,6 +765,7 @@
 		};
 		72C6235228CB1DDD0023A368 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9181DE796AB614040B75F6D2 /* Pods-HeyBunny-HeyBunnyUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/HeyBunny.xcodeproj/xcuserdata/kimdongjoon.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/HeyBunny.xcodeproj/xcuserdata/kimdongjoon.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>HeyBunny.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>8</integer>
 		</dict>
 	</dict>
 </dict>

--- a/HeyBunny/entity/News.swift
+++ b/HeyBunny/entity/News.swift
@@ -1,0 +1,17 @@
+//
+//  News.swift
+//  HeyBunny
+//
+//  Created by 김동준 on 2022/09/09.
+//
+
+import Foundation
+
+struct News: Codable {
+    let articles: [Article]
+}
+
+struct Article: Codable {
+    let title: String
+    let description: String
+}

--- a/HeyBunny/network/NewsAPI.swift
+++ b/HeyBunny/network/NewsAPI.swift
@@ -1,0 +1,65 @@
+//
+//  NewsAPI.swift
+//  HeyBunny
+//
+//  Created by 김동준 on 2022/09/09.
+//
+
+import Moya
+
+enum NewsAPI {
+    case topHeadlines
+}
+extension NewsAPI: TargetType {
+    var baseURL: URL {
+        switch self {
+        case .topHeadlines:
+            return URL(string: "https://newsapi.org/v2")!
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .topHeadlines:
+            return "/top-headlines"
+        }
+    }
+    
+    var method: Method {
+        switch self {
+        case .topHeadlines:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .topHeadlines:
+            let params: [String: Any] = [
+                "country": "kr",
+                "apiKey": "b6e4d3cf120c4f55a73c51be3e570b3d"
+            ]
+            return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+        }
+    }
+    
+    var sampleData: Data {
+        switch self {
+        case .topHeadlines:
+            return Data(
+                            """
+                            {\"status\":\"ok\",\"totalResults\":34,\"articles\":[{\"source\":{\"id\":null,\"name\":\"Hankyung.com\"},\"author\":null,\"title\":\"중국, 북한 핵무력 법제화에 \\\"한반도 문제 입장 변화없어\\\" - 한국경제\",\"description\":\"중국, 북한 핵무력 법제화에 \\\"한반도 문제 입장 변화없어\\\", 국제\",\"url\":\"https://www.hankyung.com/international/article/202209092536Y\",\"urlToImage\":\"https://img.hankyung.com/photo/202209/ZK.31176259.1.jpg\",\"publishedAt\":\"2022-09-09T08:11:55Z\",\"content\":\"\' \' .8() BBC . () (SAR) . 1954 , 2018 2020 . , BBC . 7000( 970) 22000( 3050) . , 2019 . , . (NGO) 2016 · , · . \\\"\"}]}
+                            """.utf8
+            )
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        case .topHeadlines:
+            return ["Content-Type": "application/json",
+                    "Accept": "application/json"]
+        }
+    }
+}
+

--- a/HeyBunny/network/NewsRepository.swift
+++ b/HeyBunny/network/NewsRepository.swift
@@ -1,0 +1,17 @@
+//
+//  NewsRepository.swift
+//  HeyBunny
+//
+//  Created by 김동준 on 2022/09/09.
+//
+
+import RxSwift
+
+final class NewsRepository {
+    let koreaNewsService: NewsService = NewsServiceImpl()
+}
+extension NewsRepository {
+    func requestKoreaNewsAPI() -> Single<News> {
+        koreaNewsService.getKoreaNewsAPI()
+    }
+}

--- a/HeyBunny/network/NewsService.swift
+++ b/HeyBunny/network/NewsService.swift
@@ -1,0 +1,51 @@
+//
+//  NewsService.swift
+//  HeyBunny
+//
+//  Created by 김동준 on 2022/09/09.
+//
+
+import RxSwift
+import Moya
+
+protocol NewsService {
+    var provider: MoyaProvider<NewsAPI> { get }
+    func getKoreaNewsAPI() -> Single<News>
+}
+extension NewsService {
+    func decode<T: Decodable>(from data: Data, parsingType: T.Type) throws -> T {
+        guard let decodeData = try? JSONDecoder().decode(parsingType, from: data) else {
+            throw NetworkError.parsing
+        }
+        return decodeData
+    }
+}
+
+final class NewsServiceImpl: NewsService {
+    var provider = MoyaProvider<NewsAPI>()
+
+    func getKoreaNewsAPI() -> Single<News> {
+        return Single<News>.create { [weak self] single in
+            guard let self = self else { return Disposables.create { } }
+            let task = self.provider.request(.topHeadlines, completion: { result in
+                switch result {
+                case .success(let response):
+                    print(String(data: response.data,encoding: .utf8))
+                    if let decodeData = try? self.decode(from: response.data, parsingType: News.self) {
+                        single(.success(decodeData))
+                    } else { single(.failure(NetworkError.parsing)) }
+                case .failure(_):
+                    single(.failure(NetworkError.network))
+                }
+            })
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+}
+
+enum NetworkError: Error {
+    case network
+    case parsing
+}

--- a/HeyBunnyTests/Mock/NewServiceStub.swift
+++ b/HeyBunnyTests/Mock/NewServiceStub.swift
@@ -1,0 +1,42 @@
+//
+//  NewServiceStub.swift
+//  HeyBunnyTests
+//
+//  Created by 김동준 on 2022/09/09.
+//
+
+@testable import HeyBunny
+import RxSwift
+import Moya
+
+final class NewsServiceStub: NewsService {
+    var provider = MoyaProvider<NewsAPI>(stubClosure: MoyaProvider.immediatelyStub)
+    
+    var result: Bool
+    init(result: Bool) {
+        self.result = result
+    }
+    
+    func getKoreaNewsAPI() -> Single<News> {
+        print("hello")
+        return Single<News>.create { [weak self] single in
+            guard let self = self else { return Disposables.create { } }
+            if self.result {
+                let task = self.provider.request(.topHeadlines, completion: { result in
+                    switch result {
+                    case .success(let response):
+                        if let decodeData = try? self.decode(from: response.data, parsingType: News.self) {
+                            single(.success(decodeData))
+                        } else { single(.failure(NetworkError.parsing)) }
+                    case .failure(_):
+                        single(.failure(NetworkError.network))
+                    }
+                })
+            } else {
+                single(.failure(NetworkError.network))
+            }
+            return Disposables.create { }
+        }
+    }
+}
+

--- a/HeyBunnyTests/NewsRepositoryTests.swift
+++ b/HeyBunnyTests/NewsRepositoryTests.swift
@@ -1,0 +1,64 @@
+//
+//  NewsRepositoryTests.swift
+//  HeyBunnyTests
+//
+//  Created by 김동준 on 2022/09/09.
+//
+
+@testable import HeyBunny
+import XCTest
+import RxSwift
+
+class NewsRepositoryTests: XCTestCase {
+    var newsService: NewsService!
+    let disposebag = DisposeBag()
+    
+    func test_NewsRepository에서_getKoreaNewsAPI가_호출되면_성공하고_modelCount를_업데이트한다() throws {
+
+        //give
+        let didFinish = expectation(description: #function)
+        newsService = NewsServiceStub(result: true)
+        var result = false
+        var modelCount = 0
+       
+        //when
+        let resultObservable = newsService.getKoreaNewsAPI()
+        resultObservable.subscribe { news in
+            modelCount = news.articles.count
+            result = true
+            didFinish.fulfill()
+        } onFailure: { error in
+            result = false
+            didFinish.fulfill()
+        }
+        .disposed(by: disposebag)
+        wait(for: [didFinish], timeout: 3.0)
+        
+        //then
+        XCTAssertEqual(result, true)
+        XCTAssertEqual(modelCount, 1)
+    }
+    
+    func test_NewsRepository에서_getKoreaNewsAPI가_호출되면_실패하고_failure를_호출한다() throws {
+
+        //give
+        let didFinish = expectation(description: #function)
+        newsService = NewsServiceStub(result: false)
+        var result = false
+        
+        //when
+        let resultObservable = newsService.getKoreaNewsAPI()
+        resultObservable.subscribe { news in
+            result = false
+            didFinish.fulfill()
+        } onFailure: { _ in
+            result = true
+            didFinish.fulfill()
+        }
+        .disposed(by: disposebag)
+        wait(for: [didFinish], timeout: 1.0)
+        
+        //then
+        XCTAssertEqual(result, true)
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -10,10 +10,14 @@ target 'HeyBunny' do
   target 'HeyBunnyTests' do
     inherit! :search_paths
     # Pods for testing
+  pod 'RxTest'
   end
 
   target 'HeyBunnyUITests' do
     # Pods for testing
   end
+  pod 'RxSwift'
+  pod 'SnapKit'
+  pod 'Moya/RxSwift'
 
 end


### PR DESCRIPTION
# 뉴스 JSON 가져오는 기능 TDD로 구현완료.
> 기록 : https://eastbyeden.tistory.com/39

## 라이브러리 Moya 사용 이유
 - SampleData를 활용하여 Mock데이터를 생성하였고, 이를 활용하여 쉽게 응답을 테스트하였습니다.

## 새로 알게된 점.
 - 만약 JSON값이 nil일 때는 DTO의 변수도 옵셔널로 사용해야 한다.
 - 그렇지 않으면 json파싱 오류가 난다.

-> 테스트는 통과했지만 실서버에서 자꾸 json파싱 오류가 났다.
-> RxSwift의 Single을 활용하여 네트워크 에러를 반환하도록 설정하였기에 어느 로직에서 에러가 발생하는지 바로 확인 가능했다.